### PR TITLE
Update `ubuntudist` variable for Ubuntu to latest LTS release name

### DIFF
--- a/class/UBUNTU.var
+++ b/class/UBUNTU.var
@@ -1,1 +1,1 @@
-ubuntudist=xenial
+ubuntudist=bionic


### PR DESCRIPTION
Ubuntu 18.04 LTS (Bionic Beaver) released a few weeks ago, thought I'd submit this PR to get it made the default Ubuntu version installed.