### PR TITLE
DHCP client during deployment != DHCP client in production

### DIFF
--- a/class/10-base-classes
+++ b/class/10-base-classes
@@ -9,13 +9,4 @@ fi
 uname -s | tr '[:lower:]' '[:upper:]'
 [ -x "`which dpkg`" ] && dpkg --print-architecture | tr a-z A-Z
 
-# determin if we are a DHCP client or not
-# count the : chars in the argument of ip=
-n="${ip//[^:]}"
-if [[ $ip =~ ^(on|any|dhcp)$ ]]; then
-    echo DHCPC
-elif [ ${#n} -lt 6 ]; then
-    echo DHCPC
-fi
-
 exit 0


### PR DESCRIPTION
The logic is nice, but the assumption is wrong IMHO:
You may wish to install a server IP configuration with DHCP but assign a static IP configuration to the server setup itself.
At least that is true for the majority of our FAI installs.