### PR TITLE
LUKS FDE support

### DIFF
--- a/class/FDE.profile
+++ b/class/FDE.profile
@@ -6,4 +6,4 @@ Short: GRUB2 booting LUKS1 FDE from encrypted /boot
 Long: Debian FAI installation using LUKS1 Full Disk Encryption on GRUB2.
 This is true Full Disk Encryption as /boot is equally encrypted. Remember
 to set a LUKS password to be able to unlock GRUB.
-Classes: INSTALL DEBIAN FDE
+Classes: INSTALL DEBIAN AMD64 FDE

--- a/class/FDE.profile
+++ b/class/FDE.profile
@@ -1,0 +1,9 @@
+Default: FDE
+
+Name: FDE
+Description: Full Disk Encryption
+Short: GRUB2 booting LUKS1 FDE from encrypted /boot
+Long: Debian FAI installation using LUKS1 Full Disk Encryption on GRUB2.
+This is true Full Disk Encryption as /boot is equally encrypted. Remember
+to set a LUKS password to be able to unlock GRUB.
+Classes: INSTALL DEBIAN FDE

--- a/class/FDE.var
+++ b/class/FDE.var
@@ -1,0 +1,28 @@
+### FDE
+
+export FAI_FLAGS="verbose debug menu sshd createvt initial";
+export HOSTNAME="DebianFDE";
+
+### FDE requirements:
+export LUKSPW="fai";
+### Grab first disk identifier
+export FAIDISK="$(/usr/lib/fai/fai-disk-info | sed 's/\s+.*//g')";
+### Needed to make GRUB2 boot off LUKS1 FDE device
+export BOOT_DISK="/dev/${FAIDISK}";
+### Set this to enable LUKS1 FDE
+export CRYPT_DEV="${BOOT_DISK}1";
+
+
+ROOTPW='$1$kBnWcO.E$djxB128U7dMkrltJHPf6d1'
+
+# errors in tasks greater than this value will cause the installation to stop
+STOP_ON_ERROR=700
+
+# set parameter for install_packages(8)
+MAXPACKAGES=800
+
+# a user account will be created
+username=demo
+USERPW='$1$kBnWcO.E$djxB128U7dMkrltJHPf6d1'
+
+### EOF

--- a/disk_config/FDE
+++ b/disk_config/FDE
@@ -1,0 +1,14 @@
+### cryptsetup luks1 on msdos only! grub support for luks2 is not yet available
+disk_config disk1 disklabel:msdos bootable:1 fstabkey:uuid align-at:1M
+primary - 100%	-	-
+
+disk_config cryptsetup
+luks	-	disk1.1	-	- lukscreateopts="--type luks1"
+
+disk_config lvm fstabkey:uuid
+vg vg1  disk1.1
+vg1-root    /     30%-     ext4    defaults,errors=remount-ro,noatime,rw
+vg1-var     /var   10G     ext4    defaults,errors=remount-ro,noatime,rw
+vg1-swap    swap    2G     swap    sw
+
+### EOF

--- a/hooks/debconf.FDE
+++ b/hooks/debconf.FDE
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+target="${target:?}";
+
+luksKeyfileDir="/etc/luks/";
+luksContainer="crypt_dev_${CRYPT_DEV##/dev/}";
+luksTmpCont="${LOGDIR}/${luksContainer}";
+luksKeyfile="${luksKeyfileDir}/${luksContainer}.keyfile";
+confFilename="50_LUKS1-FDE";
+
+createCrypttab() {
+  cryptUuid="$(blkid -s UUID -o value "${CRYPT_DEV}")";
+  if test -n "$CRYPT_DEV" -a -n "$cryptUuid"; then
+    echo "${luksContainer} UUID=$cryptUuid ${luksKeyfile} luks,discard,loud,initramfs" > "${target}/etc/crypttab"
+  else
+    exit 1;
+  fi;
+}
+
+enableFDE () {
+  ainsl -a /etc/default/grub.d/${confFilename}.cfg "GRUB_CMDLINE_LINUX=\"cryptdevice=${CRYPT_DEV}:${luksContainer}\"";
+  ainsl -a /etc/default/grub.d/${confFilename}.cfg "GRUB_ENABLE_CRYPTODISK=y";
+
+  ainsl -a /etc/cryptsetup-initramfs/conf-hook "CRYPTSETUP=y"
+  ainsl -a /etc/cryptsetup-initramfs/conf-hook "KEYFILE_PATTERN=${luksKeyfileDir}/*.keyfile"
+
+  ainsl -a /etc/initramfs-tools/conf.d/${confFilename}.conf "UMASK=0077"
+
+  createCrypttab;
+
+  install -vd -m 700 "${target}/${luksKeyfileDir}/"
+  install -v  -m 400 "${luksTmpCont}" "${target}/${luksKeyfile}"
+}
+
+addLuksPW() {
+  ### Add automatically generated key from keyslot#1 to keyslot#2
+  cryptsetup luksAddKey --key-slot 2 "${CRYPT_DEV}" --key-file "${target}/${luksKeyfile}" "${target}/${luksKeyfile}";
+  ### Add password to keyslot#1
+  ### This reduces boot time as grub tries to match keys to all keyslots, starting 
+  ### at #0 (LUKS1) or #1 (LUKS2). As the grub implementation of PBKDF is not optimized 
+  ### nor possibly adapted to the target CPU.
+  ### Make grub find the password slot at first try.
+  cryptsetup luksRemoveKey --key-slot 1 "${CRYPT_DEV}" "${target}/${luksKeyfile}" || true;
+  echo "$LUKSPW" | cryptsetup luksAddKey --key-slot 1 "${CRYPT_DEV}" --key-file "${target}/${luksKeyfile}";
+
+  ### https://unix.stackexchange.com/questions/535077/convert-luks2-back-to-luks-version-1
+  ### In case a LUKS2 container was created, convert it back to LUKS1:
+  #echo "$LUKSPW" | cryptsetup luksConvertKey --pbkdf=pbkdf2 "${CRYPT_DEV}";
+  #echo "$LUKSPW" | cryptsetup convert --type luks1 "${CRYPT_DEV}";
+}
+
+if test -n "$CRYPT_DEV"; then
+  echo "$0: INFO: Enabling LUKS1 Full Disk Encryption with GRUB2.";
+  enableFDE;
+  ### If $LUKSPW is set then move key-file to next slot and install $LUKSPW before that.
+  if test -n "$LUKSPW"; then
+    echo "$0: INFO: Adding Password to LUKS1 key-slot.";
+    addLuksPW;
+  else
+    echo "$0: ERR: Sorry, LUKS password missing but Full Disk Encryption configured. This setup will fail to boot without LUKS password set.";
+    exit 700;
+  fi;
+fi;
+
+### EOF

--- a/hooks/debconf.FDE
+++ b/hooks/debconf.FDE
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+### (c) 2019 corbolais@gmail.com
+
 target="${target:?}";
 
 luksKeyfileDir="/etc/luks/";
@@ -58,7 +60,7 @@ if test -n "$CRYPT_DEV"; then
     addLuksPW;
   else
     echo "$0: ERR: Sorry, LUKS password missing but Full Disk Encryption configured. This setup will fail to boot without LUKS password set.";
-    exit 700;
+    exit 128;
   fi;
 fi;
 

--- a/package_config/FDE
+++ b/package_config/FDE
@@ -1,0 +1,5 @@
+### LUKS1 FDE packages
+PACKAGES install-norec FDE
+lvm2
+cryptsetup cryptsetup-initramfs
+initramfs-tools

--- a/scripts/GRUB_EFI/10-setup
+++ b/scripts/GRUB_EFI/10-setup
@@ -25,7 +25,7 @@ if [ -z "$BOOT_DEVICE" ]; then
 fi
 
 # disable os-prober because of #788062
-ainsl /etc/default/grub 'GRUB_DISABLE_OS_PROBER=true'
+ainsl -a /etc/default/grub.d/80_os_prober.cfg 'GRUB_DISABLE_OS_PROBER=true'
 
 # skip the rest, if not an initial installation
 if [ $FAI_ACTION != "install" ]; then
@@ -33,7 +33,11 @@ if [ $FAI_ACTION != "install" ]; then
     exit $error
 fi
 
-GROOT=$($ROOTCMD grub-probe -tdrive -d $BOOT_DEVICE)
+if test -n "$BOOT_DISK"; then
+    GROOT="$BOOT_DISK";
+else
+    GROOT=$($ROOTCMD grub-probe -tdrive -d $BOOT_DEVICE)
+fi;
 
 # handle /boot in lvm-on-md
 _bdev=$(readlink -f $BOOT_DEVICE)
@@ -60,7 +64,7 @@ elif [[ $BOOT_DEVICE =~ '/dev/loop' ]]; then
 else
     $ROOTCMD grub-install --no-floppy --modules=part_gpt "$GROOT"
     if [ $? -eq 0 ]; then
-        echo "Grub installed on $BOOT_DEVICE = $GROOT"
+        echo "Grub installed on \"$BOOT_DEVICE\" on \"$GROOT\"";
     fi
 fi
 $ROOTCMD update-grub

--- a/scripts/GRUB_PC/10-setup
+++ b/scripts/GRUB_PC/10-setup
@@ -17,7 +17,7 @@ if [ -z "$BOOT_DEVICE" ]; then
 fi
 
 # disable os-prober because of #788062
-ainsl /etc/default/grub 'GRUB_DISABLE_OS_PROBER=true'
+ainsl -a /etc/default/grub.d/80_os_prober.cfg 'GRUB_DISABLE_OS_PROBER=true'
 
 # skip the rest, if not an initial installation
 if [ $FAI_ACTION != "install" ]; then
@@ -25,7 +25,11 @@ if [ $FAI_ACTION != "install" ]; then
     exit $error
 fi
 
-GROOT=$($ROOTCMD grub-probe -tdrive -d $BOOT_DEVICE)
+if test -n "$BOOT_DISK"; then
+    GROOT="$BOOT_DISK";
+else
+    GROOT=$($ROOTCMD grub-probe -tdrive -d $BOOT_DEVICE)
+fi;
 
 # handle /boot in lvm-on-md
 _bdev=$(readlink -f $BOOT_DEVICE)
@@ -44,7 +48,7 @@ if [[ $BOOT_DEVICE =~ '/dev/md' ]]; then
 else
     $ROOTCMD grub-install --no-floppy "$GROOT"
     if [ $? -eq 0 ]; then
-        echo "Grub installed on $BOOT_DEVICE = $GROOT"
+        echo "Grub installed for \"$BOOT_DEVICE\" on \"$GROOT\""
     fi
 fi
 $ROOTCMD update-grub


### PR DESCRIPTION
- creates a new install template `FDE` serving as an example and -- once installed -- boots a Debian buster with real LUKS1 Full Disk Encryption (i.e. no exposed `/boot`, it is equally encrypted).
- on boot-up, there's a cryptsetup password prompt before entering GRUB boot menu.
- tested with: Debian buster, FAI 5.8.4
- requires `LUKS FDE support` [fai PR #88](https://github.com/faiproject/fai/pull/88)

Signed-off-by: corbolais <corbolais@gmail.com>