### PR TITLE
[DEBIAN] Remove duplicated unattended-upgrades entry in package_config

### DIFF
--- a/package_config/DEBIAN
+++ b/package_config/DEBIAN
@@ -44,6 +44,3 @@ grub-efi
 
 PACKAGES install LVM
 lvm2
-
-PACKAGES install CLOUD
-unattended-upgrades


### PR DESCRIPTION
The 'unattended-upgrades' package is already installed for all systems
in the DEBIAN class (see line 16 of package_config/DEBIAN), no need to
explicity declare it for systems in DEBIAN & CLOUD classes.