### PR TITLE
Do not generate EFI classes if GRUB_PC is already in classes

### DIFF
--- a/class/85-efi-classes
+++ b/class/85-efi-classes
@@ -2,7 +2,7 @@
 
 # define classes for disk_config in an EFI enironment
 
-if [ ! -d /sys/firmware/efi ]; then
+if [ ! -d /sys/firmware/efi ] || ifclass GRUB_PC; then
     exit 0
 fi
 


### PR DESCRIPTION
This change allows easily building BIOS images on UEFI-enabled build hosts.