### PR TITLE
exclude /var/lib/dbus/machine-id from basefiles t…

### DIFF
--- a/basefiles/mk-basefile
+++ b/basefiles/mk-basefile
@@ -134,7 +134,7 @@ cleanup-rinse() {
 
 tarit() {
 
-    tar $attributes --numeric-owner --one-file-system -C $xtmp -cf - --exclude etc/machine-id --exclude var/lib/dbus/machine-id . | $zip > $target.$ext
+    tar $attributes --numeric-owner --one-file-system -C $xtmp -cf - --exclude var/lib/dbus/machine-id . | $zip > $target.$ext
 }
 
 

--- a/basefiles/mk-basefile
+++ b/basefiles/mk-basefile
@@ -134,7 +134,7 @@ cleanup-rinse() {
 
 tarit() {
 
-    tar $attributes --numeric-owner --one-file-system -C $xtmp -cf - . | $zip > $target.$ext
+    tar $attributes --numeric-owner --one-file-system -C $xtmp -cf - --exclude etc/machine-id --exclude var/lib/dbus/machine-id . | $zip > $target.$ext
 }
 
 


### PR DESCRIPTION
this change updates the `mk-basefile` script to exclude `/etc/machine-id` and `/var/lib/dbus/machine-id` from basefiles to allow unique builds.  in testing it appears that removing both is necessary (cf. `SYSTEMD-MACHINE-ID-SETUP(1)` "If a valid D-Bus machine ID is already configured [...]").  tested on a FOCAL64 basefile.

it is worth noting that the `create_base` function in `bin/fai-make-nfsroot` currently only excludes `/etc/machine-id`.  likely this should be updated as well.