### PR TITLE
not properly testing for length of kernelname variable (missing $)

### DIFF
--- a/class/DEBIAN.var
+++ b/class/DEBIAN.var
@@ -35,7 +35,7 @@ elif ifclass AMD64; then
    kernelname=linux-image-amd64
 fi
 
-if [ -z "kernelname" ]; then
+if [ -z "$kernelname" ]; then
     _arch=$(dpkg --print-architecture 2>/dev/null)
     case $_arch in
         i386)


### PR DESCRIPTION
the `-z` test in `class/DEBIAN.var` for an empty `$kernelname` variable was missing the "$" and thus always false as it tested the literal string "kernelname"