### PR TITLE
modify CHROOT stanza in package_config/DEBIAN to use kernelname variable

### DIFF
--- a/package_config/DEBIAN
+++ b/package_config/DEBIAN
@@ -38,8 +38,7 @@ PACKAGES install-norec I386 AMD64
 memtest86+
 
 PACKAGES install-norec CHROOT
-linux-image-686-pae-
-linux-image-amd64-
+${kernelname}- # see class/DEBIAN.var
 
 PACKAGES install-norec AMD64
 ${kernelname} # see class/DEBIAN.var


### PR DESCRIPTION
when the `$kernelname` variable was introduced the `CHROOT` stanza in `package_config/DEBIAN` (which removes kernel packages) was not updated.  when the `CHROOT` class is set this results in the error and failure described below which is resolved with this commit.

with fai 5.10.3 trying to install an unknown package just resulted in a warning and the remainder of the listed packages were installed:
```
WARNING: These unknown packages are removed from the installation list: linux-image-686-pae- linux-image-amd64-
install_packages: executing chroot /tmp/tmp.NU3i3yzi9I apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew --fix-missing install linux-image-generic- ubuntu-minimal ubuntu-server
Reading package lists...
Building dependency tree...
Reading state information...
Package 'linux-image-generic' is not installed, so not removed
ubuntu-minimal is already the newest version (1.481.1).
The following additional packages will be installed:
[...]
```
but in 6.2.2 it is now an error and that installation list fails (i am uncertain why it only errors on the first package it is unable to locate):
```
install_packages: executing chroot /tmp/tmp.JmA73mZvzS apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew --allow-change-held-packages --fix-missing install --no-install-recommends ${acpisupportname} kbd udev bash-completion debconf-utils file zstd less linuxlogo rsync openssh-client openssh-server time procinfo nullmailer sudo locales console-setup kbd pciutils usbutils unattended-upgrades linux-image-686-pae- linux-image-amd64- ansible facter python3-requests git libpam-systemd gnupg ubuntu-standard ubuntu-server- linux-image-virtual
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package linux-image-686-pae
Package 'linux-image-amd64' is not installed, so not removed
ERROR: 25600 25600
ERROR: chroot /tmp/tmp.JmA73mZvzS apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew --allow-change-held-packages --fix-missing install --no-install-recommends  ${acpisupportname} kbd udev bash-completion debconf-utils file zstd less linuxlogo rsync openssh-client openssh-server time procinfo nullmailer sudo locales console-setup kbd pciutils usbutils unattended-upgrades linux-image-686-pae- linux-image-amd64- ansible facter python3-requests git libpam-systemd gnupg ubuntu-standard ubuntu-server- linux-image-virtual return code 100
install_packages: executing chroot /tmp/tmp.JmA73mZvzS apt-get clean
install_packages: executing chroot /tmp/tmp.JmA73mZvzS dpkg --configure --pending
install_packages: executing chroot /tmp/tmp.JmA73mZvzS dpkg -C
install_packages: executing chroot /tmp/tmp.JmA73mZvzS apt-get clean
1 errors during executing of install_packages
Exit code task_instsoft: 471
```
with this patch applied the 6.2.2 `install_packages` works again in this situation:
```
install_packages: executing chroot /tmp/tmp.LDY5LAXYlG apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew --allow-change-held-packages --fix-missing install ubuntu-minimal ubuntu-server ${kernelname}-
Reading package lists...
Building dependency tree...
Reading state information...
Package 'linux-image-generic' is not installed, so not removed
ubuntu-minimal is already the newest version (1.481.1).
The following additional packages will be installed:
[...]
```