### PR TITLE
GRUB_EFI: arm64 grub EFI installation support

### DIFF
--- a/scripts/GRUB_EFI/10-setup
+++ b/scripts/GRUB_EFI/10-setup
@@ -46,7 +46,13 @@ if [ "${_bdev%%-*}" = "/dev/dm" ]; then
   BOOT_DEVICE=$( lvs --noheadings -o devices $BOOT_DEVICE | sed -e 's/^*\([^(]*\)(.*$/\1/' )
 fi
 
-opts="--no-floppy --target=x86_64-efi --modules=part_gpt"
+# ARM64 or AMD64
+arch=$(uname -m)
+if [ "$arch" == "aarch64" ]; then
+    opts="--no-floppy --modules=part_gpt"
+else
+    opts="--no-floppy --target=x86_64-efi --modules=part_gpt"
+fi
 
 # Check if RAID is used for the boot device
 if [[ $BOOT_DEVICE =~ '/dev/md' ]]; then


### PR DESCRIPTION
The "--target=x86_64-efi" option obviously does not work for arm64 installation. Skip it in case of an arm64 installation, the x86-64 default is unchanged.

NB: This work comes from the SEAPATH project: https://github.com/seapath/build_debian_iso/pull/121